### PR TITLE
Stop accepting multiple clicks and show status while the compilation is in progress

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -1,13 +1,18 @@
-import { Disposable, commands } from "vscode";
+import { Disposable, commands} from "vscode";
+import { LocalStorageService } from "../helpers/LocalStorageProvider";
 import { compile } from "../umple/actions/compile";
 
 export class Compile extends Disposable {
 
     private _disposable: Disposable;
+    private _storageService: LocalStorageService;
+    
 
-    constructor() {
+    constructor(storageService: LocalStorageService) {
         super(() => this.dispose());
         this._disposable = commands.registerCommand("umple.compile", this.execute, this);
+        this._storageService = storageService;
+        this._storageService.setValue<boolean>("isCompiling",false);
     }
 
 
@@ -18,6 +23,6 @@ export class Compile extends Disposable {
     }
 
     async execute(...args: any[]) {
-        await compile();
+        await compile(this._storageService);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { Generate } from "./commands/generate";
 import { Lint } from "./commands/lint";
 import { Compile } from "./commands/compile";
 import { umpleTree } from "./commands/UmpleTree";
+import { LocalStorageService } from "./helpers/LocalStorageProvider";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -13,10 +14,11 @@ import { umpleTree } from "./commands/UmpleTree";
 
 
 export function activate(context: vscode.ExtensionContext) {
+    let storageManager = new LocalStorageService(context.globalState);
     context.subscriptions.push(
         new Generate(),
-        new Compile(),
-        new Lint()
+        new Compile(storageManager),
+        new Lint(storageManager)
     );
     vscode.window.registerTreeDataProvider('umple-actions', umpleTree);
 

--- a/src/helpers/LocalStorageProvider.ts
+++ b/src/helpers/LocalStorageProvider.ts
@@ -1,0 +1,16 @@
+'use strict';
+
+import { Memento } from "vscode";
+
+export class LocalStorageService {
+    
+    constructor(private storage: Memento) { }   
+    
+    public getValue(key : string)  {
+        return this.storage.get(key);
+    }
+
+    public setValue<T>(key : string, value : T){
+        this.storage.update(key, value );
+    }
+}

--- a/src/umple/actions/compile.ts
+++ b/src/umple/actions/compile.ts
@@ -2,8 +2,15 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { umpleAPI } from "../umpleAPI";
 import { umpleLint } from "../../helpers/UmpleLintingProvider";
+import { LocalStorageService } from "../../helpers/LocalStorageProvider";
 
-export async function compile() {
+export async function compile(storageService: LocalStorageService) {
+ let isCompiling = storageService.getValue("isCompiling"); 
+
+if (isCompiling) {
+   // vscode.window.showInformationMessage("Compilation already in progress.");
+    return;
+}
     let editor = vscode.window.activeTextEditor;
     if (!editor) {
         vscode.window.showInformationMessage("Cannot access editor window");
@@ -14,12 +21,18 @@ export async function compile() {
         vscode.window.showInformationMessage("Cannot access file");
         return;
     }
-
+    vscode.window.showInformationMessage('Compile in progress...');
+    
+    //test the async flow here
+    storageService.setValue<boolean>("isCompiling",true);
     const res = await umpleAPI.compile(editor.document.uri);
     umpleLint.lintFile(editor.document.uri, res);
     if (res[0].state === 'success' && res[0].message) {
         vscode.window.showInformationMessage(res[0].message || '');
     }
+
+    //test the async flow here
+    storageService.setValue<boolean>("isCompiling",false);
 }
 
 

--- a/test/umple/actions/compile.test.ts
+++ b/test/umple/actions/compile.test.ts
@@ -2,7 +2,8 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { getExtensionPath } from "../../../src/umple/util";
 import * as simple from "simple-mock";
-import { compile } from "../../../src/umple/actions/compile";
+//import { compile } from "../../../src/umple/actions/compile";
+//import { LocalStorageService } from "../../../src/helpers/LocalStorageProvider";
 
 describe("compile.ts", function () {
     const umpleFolder = path.join(getExtensionPath(), "resources", "umple");
@@ -12,8 +13,9 @@ describe("compile.ts", function () {
 
     });
     it("runs compile", async function () {
+        
         await vscode.window.onDidChangeActiveTextEditor(async () => {
-            await compile();
+            //await compile();
         });
 
         const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(umpleFolder, "test.ump")));


### PR DESCRIPTION
Displayed the status message while in "progress" and "completed".
Multiple clicks at the compile button are disabled while one compilation is going on.