### PR TITLE
Add update for umple.jar when there is a new version of umple release

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,17 @@
                     "name": "Actions"
                 }
             ]
-        }
+        },
+        "configuration": {
+            "title": "Umple",
+            "properties": {
+                "umple.update": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Update to the latest officially released version of the umple jar."
+                }
+            }
+        }      
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { Lint } from "./commands/lint";
 import { Compile } from "./commands/compile";
 import { umpleTree } from "./commands/UmpleTree";
 import { LocalStorageService } from "./helpers/LocalStorageProvider";
+import { updateUmple } from "./umple/util";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -21,7 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
         new Lint(storageManager)
     );
     vscode.window.registerTreeDataProvider('umple-actions', umpleTree);
-
+    updateUmple();
 }
 
 // this method is called when your extension is deactivated

--- a/src/umple/util.ts
+++ b/src/umple/util.ts
@@ -1,5 +1,6 @@
 import * as child_process from "child_process";
 import * as vscode from "vscode";
+import * as fs from 'fs';
 
 
 export function testJava(): boolean {
@@ -12,7 +13,6 @@ export function compileJava(uri: vscode.Uri): boolean {
         child_process.execSync(`javac ${uri.fsPath}`);
         return true;
     } catch (err) {
-        console.log(err);
         return false;
     }
 }
@@ -28,4 +28,31 @@ export function getExtensionPath(): string {
         throw Error("Cannot find Extension");
     }
     return extension.extensionPath;
+}
+
+export function updateUmple() {
+    let config = vscode.workspace.getConfiguration("umple");
+    if (!config.get('update')) {
+        return;
+    }
+    
+    let latestVersion: string;
+    try {
+        latestVersion = child_process.execSync(`curl -L https://cruise.umple.org/umpleonline/scripts/versionRunning.txt`).toString();
+        latestVersion = latestVersion.trim();
+    } catch (error) {
+        return;
+    }
+
+    if (fs.existsSync(`${getExtensionPath()}/umple.jar`)) {
+        let currentVersion = child_process.execSync(`java -jar ${getExtensionPath()}/umple.jar -v`).toString().replace("Version: ", "");
+        currentVersion = currentVersion.trim();
+        if (latestVersion !== currentVersion) {
+            child_process.execSync(`curl https://try.umple.org/scripts/umple.jar --output ${getExtensionPath()}/umple.jar`);
+        }
+    } else {
+        child_process.execSync(`curl https://try.umple.org/scripts/umple.jar --output ${getExtensionPath()}/umple.jar`);
+    }
+
+    
 }


### PR DESCRIPTION
[#1988](https://github.com/umple/umple/issues/1988)
Update umple jar file in VSCode extension when there is a new version of Umple is released.
The extension checks the version of umple when it is activated. (open vscode & onLanguage: ump)
The user can turn this off in extension settings.